### PR TITLE
Completed the functionality for adding space to instance name

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -11,7 +11,7 @@ const Schemas = {};
 Schemas.Instance = new SimpleSchema({
   tablename: {
     type: String,
-    regEx: /^[0-9a-zA-Z \b]+$/ // Regular expression to accept string containing at least one letter and optionally is followed by number or space or any other letter.
+    regEx: /^[0-9a-zA-Z \b]{4,30}$/ // Regular expression to accept string containing at least one letter and optionally is followed by number or space or any other letter.
   },
   threshold: {
     type: Number,
@@ -81,7 +81,7 @@ Schemas.Question = new SimpleSchema({
   },
   tablename: {
     type: String,
-    regEx: /^[0-9a-zA-Z \b]+$/ // Regular expression to accept string containing at least one letter and optionally is followed by number or space or any other letter.
+    regEx: /^[0-9a-zA-Z \b]{4,30}$/ // Regular expression to accept string containing at least one letter and optionally is followed by number or space or any other letter.
   },
   text: {
     type: String,


### PR DESCRIPTION
The pull request is implementation for the feature listed in issue #14792 and #12582. The instance name can be made by using space between words or digits but no other special character is allowed. The corresponding regular expression was updated to update the table name accepting regular expression.